### PR TITLE
Fix calendar event sync glitch

### DIFF
--- a/app script
+++ b/app script
@@ -1281,13 +1281,15 @@ function pruneDeletedEventRefsForRow_(row, cal, emailsMap, skipColsSet){
     }
 
     var isEditedCol = !!(skipColsSet && skipColsSet[c]);
+    var isOnEditPass = !!skipColsSet; // any presence indicates we're in an onEdit/queued edit context
 
     if (!ev || !stillGuest) {
-      if (isEditedCol) {
-        // User just pasted/typed here: drop the stale note but PRESERVE the value
+      if (isOnEditPass) {
+        // During an edit pass, never clear values in any column. Only drop stale notes.
+        // This prevents fast delete-then-paste moves from being reverted.
         cell.setNote('');
       } else {
-        // Clear value+note only when not part of the current edit pass
+        // Outside edit context (manual/windowed operations), it's safe to clear both.
         cell.setValue('');
         cell.setNote('');
       }


### PR DESCRIPTION
Prevent cell value clearing during `onEdit` passes to fix event reversion glitches on quick cut/paste operations.

Previously, the `onEdit` cleanup could clear values in non-edited columns while a user was mid-move (e.g., deleting from one cell and pasting into another). This caused the system to revert the newly pasted content. The updated logic ensures that during any `onEdit` pass, only stale notes are removed, preserving cell values across the row and eliminating the need for users to wait for a toast before pasting.

---
<a href="https://cursor.com/background-agent?bcId=bc-91879ef6-fbcc-4a12-a524-2bbc562f8a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91879ef6-fbcc-4a12-a524-2bbc562f8a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

