### PR TITLE
Fix calendar title update when CALENDAR_WINS_TITLE_DATE is false

### DIFF
--- a/app script
+++ b/app script
@@ -146,10 +146,12 @@ function onEditHandler(e){
               }
               upsertDescriptionKeepUserContent_(targetEvent, title);
               if (!hasGuest_(targetEvent, email)) { try { targetEvent.addGuest(email); } catch(_) {} }
-              var titleFromCal = CALENDAR_WINS_TITLE_DATE ? collapseWhitespace_(targetEvent.getTitle() || '') : title;
-              if (!CALENDAR_WINS_TITLE_DATE && titleFromCal !== title) { try { targetEvent.setTitle(title); titleFromCal = title; } catch(_) {} }
-              if (String(cell.getValue() || '').trim() !== titleFromCal) { cell.setValue(titleFromCal); }
-              cell.setNote(JSON.stringify({ eventId: canonicalId_(targetEvent.getId()), titleKey: normalizeKey_(titleFromCal), syncedAt: new Date().toISOString() }));
+              var evTitleNow = collapseWhitespace_(targetEvent.getTitle() || '');
+              if (!CALENDAR_WINS_TITLE_DATE && evTitleNow !== title) {
+                try { targetEvent.setTitle(title); evTitleNow = title; } catch(_) {}
+              }
+              if (String(cell.getValue() || '').trim() !== evTitleNow) { cell.setValue(evTitleNow); }
+              cell.setNote(JSON.stringify({ eventId: canonicalId_(targetEvent.getId()), titleKey: normalizeKey_(evTitleNow), syncedAt: new Date().toISOString() }));
               return;
             }
           }


### PR DESCRIPTION
Fix `onEditHandler` to correctly update calendar event titles from the sheet when `CALENDAR_WINS_TITLE_DATE` is false.

Previously, when `CALENDAR_WINS_TITLE_DATE` was false, the `titleFromCal` variable was immediately assigned the sheet's title. This made the subsequent condition `titleFromCal !== title` always false, preventing the calendar event's title from being updated from the sheet as intended. The fix now compares the actual current event title with the sheet's title before attempting to update.

---
<a href="https://cursor.com/background-agent?bcId=bc-436c877b-4a7d-430f-8537-3b9f17715fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-436c877b-4a7d-430f-8537-3b9f17715fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

