### PR TITLE
Fix event id not deleting from cell

### DIFF
--- a/app script
+++ b/app script
@@ -958,6 +958,26 @@ function finalValidationSweep_() {
     var rowDayKey = rowDate ? dateKey_(rowDate) : null;
     for (var c0 = 1; c0 < lastCol; c0++) {
       var note = String(notes[r0][c0] || '').trim();
+      var rawNow = String(values[r0][c0] || '').trim();
+      // If user cleared or typed CANCEL but note still has an eventId, unlink and clear
+      if (note && (!rawNow || equalsIgnoreCase_(rawNow, CANCEL_TOKEN))) {
+        try {
+          var emailLowerDel = String(emailRow[c0] || '').trim().toLowerCase();
+          var evIdDel = parseEventIdFromNote_(note);
+          if (evIdDel) {
+            var evDel = getEventByIdSafe_(cal, evIdDel);
+            if (evDel && emailLowerDel) { removeGuestAndDeleteIfEmpty_(evDel, emailLowerDel); }
+          }
+          // Record suppression to avoid immediate re-create on next outbound pass
+          try {
+            var tKeyDel = parseTitleKeyFromNote_(note);
+            if (rowDayKey && tKeyDel && emailLowerDel) { addSuppression_(rowDayKey, tKeyDel, emailLowerDel, RECREATE_SUPPRESS_HOURS); }
+          } catch(_){ }
+        } catch(_){ }
+        values[r0][c0] = '';
+        notes[r0][c0]  = '';
+        continue;
+      }
       if (!note) continue;
       var evId = parseEventIdFromNote_(note);
       if (!evId) { notes[r0][c0] = ''; continue; }


### PR DESCRIPTION
Add a cleanup in `finalValidationSweep_` to clear lingering event IDs from cells.

This fixes an issue where events deleted or cancelled in the sheet would remain in Google Calendar because their event IDs were not properly cleared from the cell's note.

---
<a href="https://cursor.com/background-agent?bcId=bc-cda273fb-295b-45a1-9754-5261ea2e7996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cda273fb-295b-45a1-9754-5261ea2e7996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

